### PR TITLE
Linux: Substract shared memory from cached memory

### DIFF
--- a/check_mem/check_mem.pl
+++ b/check_mem/check_mem.pl
@@ -156,6 +156,9 @@ sub get_memory_info {
             elsif (/^(Buffers|Cached|SReclaimable):\s+(\d+) kB/) {
                 $caches_kb += $2;
             }
+            elsif (/^Shmem:\s+(\d+) kB/) {
+                $caches_kb -= $1;
+            }
         }
         $used_memory_kb = $total_memory_kb - $free_memory_kb;
     }


### PR DESCRIPTION
Shared memory (which includes shared segments, ramfs, tmpfs) is counted towards cached memory but it is not freeable page cache. Therefore it should be substracted from the value 'caches_kb'. Further information is available in this Linux kernel commit: https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773