### PR TITLE
Fix typo in check_mem.pl

### DIFF
--- a/check_mem/check_mem.pl
+++ b/check_mem/check_mem.pl
@@ -403,7 +403,7 @@ sub get_memory_info {
             }
             # 'caching' concept works different on MACH
             # this should be a reasonable approximation
-            elsif (/^Pages (inactive|purgable):\s+(\d+).$/) {
+            elsif (/^Pages (inactive|purgeable):\s+(\d+).$/) {
                 $caches_kb += $2*$pagesize/1024;
             }
         }


### PR DESCRIPTION
I found this typo when running [codespell](https://github.com/codespell-project/codespell/) pre-commit hook over a local copy of check_mem.pl.  I verified that the output of `vm_stat` on macos 10.14 does contain `Pages purgeable`.